### PR TITLE
Fix french translation errors on fastlane metadata

### DIFF
--- a/fastlane/metadata/android/fr-FR/full_description.txt
+++ b/fastlane/metadata/android/fr-FR/full_description.txt
@@ -1,8 +1,8 @@
-Cryptomator rend votre stockage dans le cloud beaucoup plus sûr.  L'application chiffre les fichiers sur votre appareil mobile avant qu'ils ne soient envoyés dans votre cloud.  Même si une tierce partie obtient un accès non autorisé à vos fichiers (par exemple, une attaque de pirates informatiques), vos fichiers sont à l'abri des regards indiscrets.
+Avec Cryptomator, la clé de vos données est dans vos mains. Cryptomator chiffre vos données rapidement et facilement. Vous les envoyez sur votre service cloud favori.
 
-<b>SIMPLICITÉ</b>
+<b>SIMPLE D'UTILISATION</b>
 
-Cryptomator a été développé en mettant l'accent sur la convivialité.
+Cryptomator est un outil d'auto-défense numérique. Il vous permet de protéger vos données stockées sur le cloud vous-même et en indépendance.
 
 • Il suffit de créer un coffre-fort et d'y attribuer un mot de passe
 • Aucun compte ou configuration supplémentaire n'est nécessaire
@@ -10,30 +10,30 @@ Cryptomator a été développé en mettant l'accent sur la convivialité.
 
 * à partir d'Android 6.0 et sur smartphones avec capteur biométrique d'empreintes digitales
 
-<b>COMPATIBILITÉ</b>
+<b>COMPATIBLE</b>
 
 Cryptomator est compatible avec les systèmes de stockage dans le cloud les plus couramment utilisés et disponible pour tous les principaux systèmes d'exploitation.
 
-• Compatible avec Dropbox, Google Drive, OneDrive et les services de stockage dans le nuage basés sur WebDAV
-• Créer des coffres-forts dans le stockage local d'Android (par exemple, fonctionne avec des applications de synchronisation tierces)
+• Compatible avec Dropbox, Google Drive, OneDrive et les services de stockage dans le cloud basés sur WebDAV
+• Créer des coffres-forts sur le stockage local d'Android (fonctionne donc avec des applications de synchronisation tierces)
 • Accédez à vos coffres-forts sur tous vos appareils mobiles et ordinateurs
 
-<b>SÉCURITÉ</b>
+<b>SÉCURISÉ</b>
 
-Cryptomator pour Android est basé sur le projet open-source de Cryptomator pour Ordinateur de bureau.
+Vous n'avez pas à aveuglément accorder votre confiance à Cryptomator, car <a href="https://github.com/cryptomator/android">c'est un logiciel open-source</a>. Pour vous utilisateur, cela signifie que n'importe qui peut voir le code.
 
 • Chiffrement du contenu et des noms de fichiers via AES et une longueur de clé de 256 bits
-• Le mot de passe du coffre-fort est sécurisé par cryptage pour une meilleure résistance aux attaque par force brut
-• Les coffre-forts sont automatiquement verrouillées après la mise en arrière-plan de l'application
-• La mise en œuvre de Crypto est basée sur la bibliothèque open-source CryptoLib et est documentée publiquement
+• Le mot de passe du coffre-fort est sécurisé par cryptage pour une meilleure résistance aux attaques par force brute
+• Les coffre-forts sont automatiquement verrouillés après la mise en arrière-plan de l'application
+• La mise en œuvre de Crypto est documentée publiquement
 
-<b>UNE GÉNIALITUDE GÉNÉRAL</b>
+<b>LAURÉAT</b>
 
-Cryptomator a reçu le prix de l'innovation CeBIT 2016 pour la sécurité pratique et la confidentialité. Nous sommes fiers d'assurer la sécurité et la confidentialité des centaines de milliers d'utilisateurs du Cryptomator.
+Cryptomator a reçu le prix de l'innovation CeBIT 2016 pour la sécurité pratique et la confidentialité. Nous sommes fiers d'assurer la sécurité et la confidentialité des centaines de milliers d'utilisateurs de Cryptomator.
 
 <b>LA COMMUNAUTÉ CRYPTOMATOR</b>
 
 Rejoignez la communauté de Cryptomator et participez aux conversations avec les autres utilisateurs de Cryptomator: https://community.cryptomator.org
 
-- Suivez-nous sur Twitter @Cryptomator
-- Comme nous sur Facebook/Cryptomator
+- Suivez-nous sur Twitter <a href="https://twitter.com/Cryptomator">@Cryptomator</a>
+- Likez-nous sur Facebook <a href="https://facebook.com/Cryptomator">/Cryptomator</a>

--- a/fastlane/metadata/android/fr-FR/short_description.txt
+++ b/fastlane/metadata/android/fr-FR/short_description.txt
@@ -1,1 +1,1 @@
-Verrouillé votre cloud: Prenez en mains la sécurité de vos données
+Verrouillez votre cloud: Prenez en main la sécurité de vos données


### PR DESCRIPTION
While trying to install Cryptomator on Android using F-Droid, I noticed several typos in the description of the application.

This pull request aims to fix these issues by first updating the french translation to the revision made in df3664d and then fixing the remaining typos.

If this is an incorrect way to provide the fixed translation, could you point me to the dedicated place to do so? I tried Crowdin but it only allows editing the strings.xml file
Also this is based on feature/translations, as it seemed best suited for this