### PR TITLE
Allow loading of api keys from the non-VCS local.properties file

### DIFF
--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -275,7 +275,13 @@ def liteFlavor() {
 }
 
 def getApiKey(key) {
-	return !liteFlavor() ? System.getenv().getOrDefault(key, "") : ""
+	return !liteFlavor() ? System.getenv().getOrDefault(key, getApiKeyLocal(key)) : ""
+}
+
+def getApiKeyLocal(key) {
+	def localPropertyList = new Properties()
+	localPropertyList.load(new FileInputStream(rootProject.file("local.properties")))
+	return localPropertyList.getOrDefault(key, "")
 }
 
 def getOnedriveApiKey() {

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -279,6 +279,9 @@ def getApiKey(key) {
 }
 
 def getApiKeyLocal(key) {
+	if(!rootProject.file("local.properties").exists()) {
+		return ""
+	}
 	def localPropertyList = new Properties()
 	localPropertyList.load(new FileInputStream(rootProject.file("local.properties")))
 	return localPropertyList.getOrDefault(key, "")


### PR DESCRIPTION
This PR allows loading API keys in `presentation/build.gradle` from the `$ROOT/local.properties` file.

Load order before this PR:
1) Lite? "", else Env
2) Env? Env, else ""

Load order after this PR:
1) Lite? "", else Env
2) Env? Env, else Local
3) Local? Local, else ""