### PR TITLE
Refactored "Cloud#type"

### DIFF
--- a/data/src/apiKey/java/org/cryptomator/data/cloud/dropbox/DropboxCloudContentRepositoryFactory.java
+++ b/data/src/apiKey/java/org/cryptomator/data/cloud/dropbox/DropboxCloudContentRepositoryFactory.java
@@ -24,7 +24,7 @@ public class DropboxCloudContentRepositoryFactory implements CloudContentReposit
 
 	@Override
 	public boolean supports(Cloud cloud) {
-		return cloud.type() == DROPBOX;
+		return cloud.getType() == DROPBOX;
 	}
 
 	@Override

--- a/data/src/apiKey/java/org/cryptomator/data/cloud/onedrive/OnedriveCloudContentRepositoryFactory.java
+++ b/data/src/apiKey/java/org/cryptomator/data/cloud/onedrive/OnedriveCloudContentRepositoryFactory.java
@@ -24,7 +24,7 @@ public class OnedriveCloudContentRepositoryFactory implements CloudContentReposi
 
 	@Override
 	public boolean supports(Cloud cloud) {
-		return cloud.type() == ONEDRIVE;
+		return cloud.getType() == ONEDRIVE;
 	}
 
 	@Override

--- a/data/src/apiKey/java/org/cryptomator/data/cloud/pcloud/PCloudContentRepositoryFactory.java
+++ b/data/src/apiKey/java/org/cryptomator/data/cloud/pcloud/PCloudContentRepositoryFactory.java
@@ -24,7 +24,7 @@ public class PCloudContentRepositoryFactory implements CloudContentRepositoryFac
 
 	@Override
 	public boolean supports(Cloud cloud) {
-		return cloud.type() == PCLOUD;
+		return cloud.getType() == PCLOUD;
 	}
 
 	@Override

--- a/data/src/apkStorePlaystore/java/org/cryptomator/data/cloud/googledrive/GoogleDriveCloudContentRepositoryFactory.java
+++ b/data/src/apkStorePlaystore/java/org/cryptomator/data/cloud/googledrive/GoogleDriveCloudContentRepositoryFactory.java
@@ -25,7 +25,7 @@ public class GoogleDriveCloudContentRepositoryFactory implements CloudContentRep
 
 	@Override
 	public boolean supports(Cloud cloud) {
-		return cloud.type() == CloudType.GOOGLE_DRIVE;
+		return cloud.getType() == CloudType.GOOGLE_DRIVE;
 	}
 
 	@Override

--- a/data/src/main/java/org/cryptomator/data/cloud/crypto/CryptoCloud.java
+++ b/data/src/main/java/org/cryptomator/data/cloud/crypto/CryptoCloud.java
@@ -3,6 +3,7 @@ package org.cryptomator.data.cloud.crypto;
 import org.cryptomator.domain.Cloud;
 import org.cryptomator.domain.CloudType;
 import org.cryptomator.domain.Vault;
+import org.jetbrains.annotations.NotNull;
 
 public class CryptoCloud implements Cloud {
 
@@ -17,6 +18,7 @@ public class CryptoCloud implements Cloud {
 		return null;
 	}
 
+	@NotNull
 	@Override
 	public CloudType type() {
 		return CloudType.CRYPTO;

--- a/data/src/main/java/org/cryptomator/data/cloud/crypto/CryptoCloud.java
+++ b/data/src/main/java/org/cryptomator/data/cloud/crypto/CryptoCloud.java
@@ -20,7 +20,7 @@ public class CryptoCloud implements Cloud {
 
 	@NotNull
 	@Override
-	public CloudType type() {
+	public CloudType getType() {
 		return CloudType.CRYPTO;
 	}
 

--- a/data/src/main/java/org/cryptomator/data/cloud/crypto/CryptoCloudContentRepositoryFactory.java
+++ b/data/src/main/java/org/cryptomator/data/cloud/crypto/CryptoCloudContentRepositoryFactory.java
@@ -35,7 +35,7 @@ public class CryptoCloudContentRepositoryFactory implements CloudContentReposito
 
 	@Override
 	public boolean supports(Cloud cloud) {
-		return cloud.type() == CRYPTO;
+		return cloud.getType() == CRYPTO;
 	}
 
 	@Override

--- a/data/src/main/java/org/cryptomator/data/cloud/local/LocalStorageContentRepositoryFactory.java
+++ b/data/src/main/java/org/cryptomator/data/cloud/local/LocalStorageContentRepositoryFactory.java
@@ -31,7 +31,7 @@ public class LocalStorageContentRepositoryFactory implements CloudContentReposit
 
 	@Override
 	public boolean supports(Cloud cloud) {
-		return cloud.type() == LOCAL;
+		return cloud.getType() == LOCAL;
 	}
 
 	@Override

--- a/data/src/main/java/org/cryptomator/data/cloud/s3/S3CloudContentRepositoryFactory.java
+++ b/data/src/main/java/org/cryptomator/data/cloud/s3/S3CloudContentRepositoryFactory.java
@@ -27,7 +27,7 @@ public class S3CloudContentRepositoryFactory implements CloudContentRepositoryFa
 
 	@Override
 	public boolean supports(Cloud cloud) {
-		return cloud.type() == S3;
+		return cloud.getType() == S3;
 	}
 
 	@Override

--- a/data/src/main/java/org/cryptomator/data/cloud/webdav/WebDavCloudContentRepositoryFactory.java
+++ b/data/src/main/java/org/cryptomator/data/cloud/webdav/WebDavCloudContentRepositoryFactory.java
@@ -26,7 +26,7 @@ public class WebDavCloudContentRepositoryFactory implements CloudContentReposito
 
 	@Override
 	public boolean supports(Cloud cloud) {
-		return cloud.type() == WEBDAV;
+		return cloud.getType() == WEBDAV;
 	}
 
 	@Override

--- a/data/src/main/java/org/cryptomator/data/db/mappers/CloudEntityMapper.java
+++ b/data/src/main/java/org/cryptomator/data/db/mappers/CloudEntityMapper.java
@@ -89,8 +89,8 @@ public class CloudEntityMapper extends EntityMapper<CloudEntity, Cloud> {
 	public CloudEntity toEntity(Cloud domainObject) {
 		CloudEntity result = new CloudEntity();
 		result.setId(domainObject.id());
-		result.setType(domainObject.type().name());
-		switch (domainObject.type()) {
+		result.setType(domainObject.getType().name());
+		switch (domainObject.getType()) {
 			case DROPBOX:
 				result.setAccessToken(((DropboxCloud) domainObject).accessToken());
 				result.setUsername(((DropboxCloud) domainObject).username());
@@ -126,7 +126,7 @@ public class CloudEntityMapper extends EntityMapper<CloudEntity, Cloud> {
 				result.setWebdavCertificate(((WebDavCloud) domainObject).certificate());
 				break;
 			default:
-				throw new IllegalStateException("Unhandled enum constant " + domainObject.type());
+				throw new IllegalStateException("Unhandled enum constant " + domainObject.getType());
 		}
 		return result;
 	}

--- a/data/src/main/java/org/cryptomator/data/repository/CloudRepositoryImpl.java
+++ b/data/src/main/java/org/cryptomator/data/repository/CloudRepositoryImpl.java
@@ -47,7 +47,7 @@ class CloudRepositoryImpl implements CloudRepository {
 		List<Cloud> allClouds = mapper.fromEntities(database.loadAll(CloudEntity.class));
 
 		for (Cloud cloud : allClouds) {
-			if (cloud.type().equals(cloudType)) {
+			if (cloud.getType().equals(cloudType)) {
 				cloudsFromType.add(cloud);
 			}
 		}

--- a/data/src/test/java/org/cryptomator/data/cloud/crypto/MasterkeyCryptoCloudProviderTest.kt
+++ b/data/src/test/java/org/cryptomator/data/cloud/crypto/MasterkeyCryptoCloudProviderTest.kt
@@ -156,7 +156,7 @@ internal class MasterkeyCryptoCloudProviderTest {
 	fun testUnlockVault() {
 		val cloudType: CloudType = mock()
 
-		whenever(cloud.type()).thenReturn(cloudType)
+		whenever(cloud.type).thenReturn(cloudType)
 		whenever(vault.cloud).thenReturn(cloud)
 		whenever(vault.cloudType).thenReturn(cloudType)
 		whenever(vault.format).thenReturn(8)
@@ -183,7 +183,7 @@ internal class MasterkeyCryptoCloudProviderTest {
 	fun testUnlockLegacyVault() {
 		val cloudType: CloudType = mock()
 
-		whenever(cloud.type()).thenReturn(cloudType)
+		whenever(cloud.type).thenReturn(cloudType)
 		whenever(vault.cloud).thenReturn(cloud)
 		whenever(vault.cloudType).thenReturn(cloudType)
 		whenever(vault.format).thenReturn(7)
@@ -217,7 +217,7 @@ internal class MasterkeyCryptoCloudProviderTest {
 	fun tesChangePassword(legacy: Boolean) {
 		val cloudType: CloudType = mock()
 
-		whenever(cloud.type()).thenReturn(cloudType)
+		whenever(cloud.type).thenReturn(cloudType)
 		whenever(vault.cloud).thenReturn(cloud)
 		whenever(vault.cloudType).thenReturn(cloudType)
 		whenever(vault.format).thenReturn(7)
@@ -334,7 +334,7 @@ internal class MasterkeyCryptoCloudProviderTest {
 	private fun testVaultPasswordVault(masterkeyContent: String, unverifiedVaultConfig: Optional<UnverifiedVaultConfig>, password: String): Boolean {
 		val cloudType: CloudType = mock()
 
-		whenever(cloud.type()).thenReturn(cloudType)
+		whenever(cloud.type).thenReturn(cloudType)
 		whenever(vault.cloud).thenReturn(cloud)
 		whenever(vault.cloudType).thenReturn(cloudType)
 		whenever(vault.format).thenReturn(7)

--- a/domain/src/main/java/org/cryptomator/domain/Cloud.kt
+++ b/domain/src/main/java/org/cryptomator/domain/Cloud.kt
@@ -5,7 +5,7 @@ import java.io.Serializable
 interface Cloud : Serializable {
 
 	fun id(): Long?
-	fun type(): CloudType?
+	fun type(): CloudType
 	fun configurationMatches(cloud: Cloud?): Boolean
 	fun persistent(): Boolean
 	fun requiresNetwork(): Boolean

--- a/domain/src/main/java/org/cryptomator/domain/Cloud.kt
+++ b/domain/src/main/java/org/cryptomator/domain/Cloud.kt
@@ -5,7 +5,7 @@ import java.io.Serializable
 interface Cloud : Serializable {
 
 	fun id(): Long?
-	fun type(): CloudType
+	val type: CloudType
 	fun configurationMatches(cloud: Cloud?): Boolean
 	fun persistent(): Boolean
 	fun requiresNetwork(): Boolean

--- a/domain/src/main/java/org/cryptomator/domain/DropboxCloud.java
+++ b/domain/src/main/java/org/cryptomator/domain/DropboxCloud.java
@@ -38,6 +38,7 @@ public class DropboxCloud implements Cloud {
 		return username;
 	}
 
+	@NotNull
 	@Override
 	public CloudType type() {
 		return CloudType.DROPBOX;

--- a/domain/src/main/java/org/cryptomator/domain/DropboxCloud.java
+++ b/domain/src/main/java/org/cryptomator/domain/DropboxCloud.java
@@ -40,7 +40,7 @@ public class DropboxCloud implements Cloud {
 
 	@NotNull
 	@Override
-	public CloudType type() {
+	public CloudType getType() {
 		return CloudType.DROPBOX;
 	}
 

--- a/domain/src/main/java/org/cryptomator/domain/GoogleDriveCloud.java
+++ b/domain/src/main/java/org/cryptomator/domain/GoogleDriveCloud.java
@@ -32,7 +32,7 @@ public class GoogleDriveCloud implements Cloud {
 
 	@NotNull
 	@Override
-	public CloudType type() {
+	public CloudType getType() {
 		return CloudType.GOOGLE_DRIVE;
 	}
 

--- a/domain/src/main/java/org/cryptomator/domain/GoogleDriveCloud.java
+++ b/domain/src/main/java/org/cryptomator/domain/GoogleDriveCloud.java
@@ -30,6 +30,7 @@ public class GoogleDriveCloud implements Cloud {
 		return id;
 	}
 
+	@NotNull
 	@Override
 	public CloudType type() {
 		return CloudType.GOOGLE_DRIVE;

--- a/domain/src/main/java/org/cryptomator/domain/LocalStorageCloud.java
+++ b/domain/src/main/java/org/cryptomator/domain/LocalStorageCloud.java
@@ -32,6 +32,7 @@ public class LocalStorageCloud implements Cloud {
 		return rootUri;
 	}
 
+	@NotNull
 	@Override
 	public CloudType type() {
 		return CloudType.LOCAL;

--- a/domain/src/main/java/org/cryptomator/domain/LocalStorageCloud.java
+++ b/domain/src/main/java/org/cryptomator/domain/LocalStorageCloud.java
@@ -34,7 +34,7 @@ public class LocalStorageCloud implements Cloud {
 
 	@NotNull
 	@Override
-	public CloudType type() {
+	public CloudType getType() {
 		return CloudType.LOCAL;
 	}
 

--- a/domain/src/main/java/org/cryptomator/domain/OnedriveCloud.java
+++ b/domain/src/main/java/org/cryptomator/domain/OnedriveCloud.java
@@ -38,6 +38,7 @@ public class OnedriveCloud implements Cloud {
 		return username;
 	}
 
+	@NotNull
 	@Override
 	public CloudType type() {
 		return CloudType.ONEDRIVE;

--- a/domain/src/main/java/org/cryptomator/domain/OnedriveCloud.java
+++ b/domain/src/main/java/org/cryptomator/domain/OnedriveCloud.java
@@ -40,7 +40,7 @@ public class OnedriveCloud implements Cloud {
 
 	@NotNull
 	@Override
-	public CloudType type() {
+	public CloudType getType() {
 		return CloudType.ONEDRIVE;
 	}
 

--- a/domain/src/main/java/org/cryptomator/domain/PCloud.java
+++ b/domain/src/main/java/org/cryptomator/domain/PCloud.java
@@ -47,7 +47,7 @@ public class PCloud implements Cloud {
 
 	@NotNull
 	@Override
-	public CloudType type() {
+	public CloudType getType() {
 		return CloudType.PCLOUD;
 	}
 

--- a/domain/src/main/java/org/cryptomator/domain/PCloud.java
+++ b/domain/src/main/java/org/cryptomator/domain/PCloud.java
@@ -45,6 +45,7 @@ public class PCloud implements Cloud {
 		return username;
 	}
 
+	@NotNull
 	@Override
 	public CloudType type() {
 		return CloudType.PCLOUD;

--- a/domain/src/main/java/org/cryptomator/domain/S3Cloud.java
+++ b/domain/src/main/java/org/cryptomator/domain/S3Cloud.java
@@ -66,6 +66,7 @@ public class S3Cloud implements Cloud {
 		return displayName;
 	}
 
+	@NotNull
 	@Override
 	public CloudType type() {
 		return CloudType.S3;

--- a/domain/src/main/java/org/cryptomator/domain/S3Cloud.java
+++ b/domain/src/main/java/org/cryptomator/domain/S3Cloud.java
@@ -68,7 +68,7 @@ public class S3Cloud implements Cloud {
 
 	@NotNull
 	@Override
-	public CloudType type() {
+	public CloudType getType() {
 		return CloudType.S3;
 	}
 

--- a/domain/src/main/java/org/cryptomator/domain/Vault.java
+++ b/domain/src/main/java/org/cryptomator/domain/Vault.java
@@ -159,7 +159,7 @@ public class Vault implements Serializable {
 			this.cloud = cloud;
 
 			if (cloud != null) {
-				this.cloudType = cloud.type();
+				this.cloudType = cloud.getType();
 			}
 
 			return this;
@@ -168,7 +168,7 @@ public class Vault implements Serializable {
 		public Builder withCloudType(CloudType cloudType) {
 			this.cloudType = cloudType;
 
-			if (cloud != null && cloud.type() != cloudType) {
+			if (cloud != null && cloud.getType() != cloudType) {
 				throw new IllegalStateException("Cloud type must match cloud");
 			}
 
@@ -179,7 +179,7 @@ public class Vault implements Serializable {
 			this.name = vaultFolder.getName();
 			this.path = vaultFolder.getPath();
 			this.cloud = vaultFolder.getCloud();
-			this.cloudType = cloud.type();
+			this.cloudType = cloud.getType();
 			return this;
 		}
 

--- a/domain/src/main/java/org/cryptomator/domain/WebDavCloud.java
+++ b/domain/src/main/java/org/cryptomator/domain/WebDavCloud.java
@@ -47,7 +47,7 @@ public class WebDavCloud implements Cloud {
 
 	@NotNull
 	@Override
-	public CloudType type() {
+	public CloudType getType() {
 		return CloudType.WEBDAV;
 	}
 

--- a/domain/src/main/java/org/cryptomator/domain/WebDavCloud.java
+++ b/domain/src/main/java/org/cryptomator/domain/WebDavCloud.java
@@ -45,6 +45,7 @@ public class WebDavCloud implements Cloud {
 		return url.equals(cloud.url) && username.equals(cloud.username);
 	}
 
+	@NotNull
 	@Override
 	public CloudType type() {
 		return CloudType.WEBDAV;

--- a/domain/src/main/java/org/cryptomator/domain/usecases/cloud/AddOrChangeCloudConnection.java
+++ b/domain/src/main/java/org/cryptomator/domain/usecases/cloud/AddOrChangeCloudConnection.java
@@ -33,7 +33,7 @@ public class AddOrChangeCloudConnection {
 	}
 
 	private boolean cloudExists(Cloud cloud) throws BackendException {
-		for (Cloud storedCloud : cloudRepository.clouds(cloud.type())) {
+		for (Cloud storedCloud : cloudRepository.clouds(cloud.getType())) {
 			if (cloud.id() != null && cloud.id().equals(storedCloud.id())) {
 				continue;
 			}

--- a/domain/src/main/java/org/cryptomator/domain/usecases/cloud/LogoutCloud.java
+++ b/domain/src/main/java/org/cryptomator/domain/usecases/cloud/LogoutCloud.java
@@ -48,6 +48,6 @@ class LogoutCloud {
 					.withAccessToken(null) //
 					.build();
 		}
-		throw new IllegalStateException("Logout not supported for cloud with type " + cloud.type());
+		throw new IllegalStateException("Logout not supported for cloud with type " + cloud.getType());
 	}
 }

--- a/presentation/src/main/java/org/cryptomator/presentation/model/CloudFolderModel.kt
+++ b/presentation/src/main/java/org/cryptomator/presentation/model/CloudFolderModel.kt
@@ -17,7 +17,7 @@ class CloudFolderModel(cloudFolder: CloudFolder) : CloudNodeModel<CloudFolder>(c
 		get() = true
 
 	fun vault(): VaultModel? {
-		return if (toCloudNode().cloud?.type() == CloudType.CRYPTO) {
+		return if (toCloudNode().cloud?.type == CloudType.CRYPTO) {
 			VaultModel((toCloudNode().cloud as CryptoCloud).vault)
 		} else {
 			null

--- a/presentation/src/main/java/org/cryptomator/presentation/model/mappers/CloudModelMapper.kt
+++ b/presentation/src/main/java/org/cryptomator/presentation/model/mappers/CloudModelMapper.kt
@@ -22,7 +22,7 @@ class CloudModelMapper @Inject constructor() : ModelMapper<CloudModel, Cloud>() 
 	}
 
 	override fun toModel(domainObject: Cloud): CloudModel {
-		return when (domainObject.type().let { CloudTypeModel.valueOf(it) }) {
+		return when (domainObject.type.let { CloudTypeModel.valueOf(it) }) {
 			CloudTypeModel.DROPBOX -> DropboxCloudModel(domainObject)
 			CloudTypeModel.GOOGLE_DRIVE -> GoogleDriveCloudModel(domainObject)
 			CloudTypeModel.LOCAL -> LocalStorageModel(domainObject)

--- a/presentation/src/main/java/org/cryptomator/presentation/model/mappers/CloudModelMapper.kt
+++ b/presentation/src/main/java/org/cryptomator/presentation/model/mappers/CloudModelMapper.kt
@@ -22,7 +22,7 @@ class CloudModelMapper @Inject constructor() : ModelMapper<CloudModel, Cloud>() 
 	}
 
 	override fun toModel(domainObject: Cloud): CloudModel {
-		return when (domainObject.type()?.let { CloudTypeModel.valueOf(it) }) {
+		return when (domainObject.type().let { CloudTypeModel.valueOf(it) }) {
 			CloudTypeModel.DROPBOX -> DropboxCloudModel(domainObject)
 			CloudTypeModel.GOOGLE_DRIVE -> GoogleDriveCloudModel(domainObject)
 			CloudTypeModel.LOCAL -> LocalStorageModel(domainObject)
@@ -31,7 +31,6 @@ class CloudModelMapper @Inject constructor() : ModelMapper<CloudModel, Cloud>() 
 			CloudTypeModel.S3 -> S3CloudModel(domainObject)
 			CloudTypeModel.CRYPTO -> CryptoCloudModel(domainObject)
 			CloudTypeModel.WEBDAV -> WebDavCloudModel(domainObject)
-			null -> throw IllegalStateException("The type of the object shouldn't be null")
 		}
 	}
 }

--- a/presentation/src/main/java/org/cryptomator/presentation/presenter/AuthenticateCloudPresenter.kt
+++ b/presentation/src/main/java/org/cryptomator/presentation/presenter/AuthenticateCloudPresenter.kt
@@ -114,10 +114,10 @@ class AuthenticateCloudPresenter @Inject constructor( //
 	}
 
 	private fun updateUsernameOf(cloud: Cloud, username: String): Cloud {
-		return when (cloud.type()) {
+		return when (cloud.type) {
 			CloudType.DROPBOX -> DropboxCloud.aCopyOf(cloud as DropboxCloud).withUsername(username).build()
 			CloudType.ONEDRIVE -> OnedriveCloud.aCopyOf(cloud as OnedriveCloud).withUsername(username).build()
-			else -> throw IllegalStateException("Cloud " + cloud.type() + " is not supported")
+			else -> throw IllegalStateException("Cloud " + cloud.type + " is not supported")
 		}
 	}
 
@@ -336,7 +336,7 @@ class AuthenticateCloudPresenter @Inject constructor( //
 
 	fun prepareForSavingPCloud(cloud: PCloud) {
 		getCloudsUseCase //
-			.withCloudType(cloud.type()) //
+			.withCloudType(cloud.type) //
 			.run(object : DefaultResultHandler<List<Cloud>>() {
 				override fun onSuccess(clouds: List<Cloud>) {
 					clouds.firstOrNull {


### PR DESCRIPTION
This PR turns `org.cryptomator.domain.Cloud#type()` from a nullable function into a non-nullable property. This allows for a simpler usage in Kotlin code and makes the code more idiomatic overall.