### PR TITLE
Set up Fluid Attacks for CASA tier 2 audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ local.properties
 **/fastlane/izzyscript/iod-scan-apk.php
 **/fastlane/izzyscript/current_iod-scan-apk.php
 **/fastlane/izzyscript/current_result_*.json
+
+# Fluid Attacks
+**/fastlane/fluidattacks/results.csv
+/apk_files/

--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,4 @@ local.properties
 
 # Fluid Attacks
 **/fastlane/fluidattacks/results.csv
-/apk_files/
+**/fastlane/fluidattacks/apks/**

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -336,18 +336,13 @@ platform :android do |options|
   lane :runFluidattacks do |options|
     # if you want to run it for a specific version just set e.g. version = "1.10.0"
     fluidattacks_apks_path = "fluidattacks/apks"
+    apk_types = %w[signed fdroid_signed lite_signed playstore_signed]
 
     FileUtils.mkdir("#{fluidattacks_apks_path}")
-
-    FileUtils.mkdir("#{fluidattacks_apks_path}/Cryptomator-#{version}_signed/")
-    FileUtils.mkdir("#{fluidattacks_apks_path}/Cryptomator-#{version}_fdroid_signed/")
-    FileUtils.mkdir("#{fluidattacks_apks_path}/Cryptomator-#{version}_lite_signed/")
-    FileUtils.mkdir("#{fluidattacks_apks_path}/Cryptomator-#{version}_playstore_signed/")
-
-    FileUtils.cp("release/Cryptomator-#{version}_signed.apk", "#{fluidattacks_apks_path}/Cryptomator-#{version}_signed/")
-    FileUtils.cp("release/Cryptomator-#{version}_fdroid_signed.apk", "#{fluidattacks_apks_path}/Cryptomator-#{version}_fdroid_signed/")
-    FileUtils.cp("release/Cryptomator-#{version}_lite_signed.apk", "#{fluidattacks_apks_path}/Cryptomator-#{version}_lite_signed/")
-    FileUtils.cp("release/Cryptomator-#{version}_playstore_signed.apk", "#{fluidattacks_apks_path}/Cryptomator-#{version}_playstore_signed/")
+    apk_types.each do |type|
+      FileUtils.mkdir("#{fluidattacks_apks_path}/Cryptomator-#{version}_#{type}/")
+      FileUtils.cp("release/Cryptomator-#{version}_#{type}.apk", "#{fluidattacks_apks_path}/Cryptomator-#{version}_#{type}/")
+    end
 
     puts "Run Fluidattacks. Results are in /src/fastlane/fluidattacks/results.csv"
     sh("docker run -v $(cd .. && pwd):/src -w /src fluidattacks/cli:amd64 skims scan /src/fastlane/fluidattacks/config.yaml")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -332,6 +332,29 @@ platform :android do |options|
     FileUtils.rm_r("exodus-test")
   end
 
+  desc "Run fluidattacks"
+  lane :runFluidattacks do |options|
+    # if you want to run it for a specific version just set e.g. version = "1.10.0"
+    fluidattacks_apks_path = "fluidattacks/apks"
+
+    FileUtils.mkdir("#{fluidattacks_apks_path}")
+
+    FileUtils.mkdir("#{fluidattacks_apks_path}/Cryptomator-#{version}_signed/")
+    FileUtils.mkdir("#{fluidattacks_apks_path}/Cryptomator-#{version}_fdroid_signed/")
+    FileUtils.mkdir("#{fluidattacks_apks_path}/Cryptomator-#{version}_lite_signed/")
+    FileUtils.mkdir("#{fluidattacks_apks_path}/Cryptomator-#{version}_playstore_signed/")
+
+    FileUtils.cp("release/Cryptomator-#{version}_signed.apk", "#{fluidattacks_apks_path}/Cryptomator-#{version}_signed/")
+    FileUtils.cp("release/Cryptomator-#{version}_fdroid_signed.apk", "#{fluidattacks_apks_path}/Cryptomator-#{version}_fdroid_signed/")
+    FileUtils.cp("release/Cryptomator-#{version}_lite_signed.apk", "#{fluidattacks_apks_path}/Cryptomator-#{version}_lite_signed/")
+    FileUtils.cp("release/Cryptomator-#{version}_playstore_signed.apk", "#{fluidattacks_apks_path}/Cryptomator-#{version}_playstore_signed/")
+
+    puts "Run Fluidattacks. Results are in /src/fastlane/fluidattacks/results.csv"
+    sh("docker run -v $(cd .. && pwd):/src -w /src fluidattacks/cli:amd64 skims scan /src/fastlane/fluidattacks/config.yaml")
+
+    FileUtils.rm_r("#{fluidattacks_apks_path}")
+  end
+
   desc "Create GitHub draft release"
   lane :createGitHubDraftRelease do |options|
     target_branch = "main"

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -71,6 +71,14 @@ Check if tracking added in some dependency using Izzy's script
 
 Check if tracking added in some dependency using exodus
 
+### android runFluidattacks
+
+```sh
+[bundle exec] fastlane android runFluidattacks
+```
+
+Run fluidattacks
+
 ### android createGitHubDraftRelease
 
 ```sh

--- a/fastlane/fluidattacks/config.yaml
+++ b/fastlane/fluidattacks/config.yaml
@@ -1,0 +1,135 @@
+# docker run --mount type=bind,source=<Root of repo>,target=/src fluidattacks/cli:<Tag> skims scan /src/fastlane/fluidattacks/config.yaml
+# <Root of repo>:	Path to the root of the repository.
+# <Tag>:			Tag of the tool image; usually "amd64" or "arm64".
+#					Also see: https://hub.docker.com/r/fluidattacks/cli
+#					Also see: https://web.archive.org/web/20240301173651/https://docs.fluidattacks.com/tech/scanner/standalone/casa/
+#
+# NOTE: Prefer using absolute paths over relative paths;
+#       the tool doesn't seem to handle relative paths too well in some places.
+namespace: CryptomatorAndroid
+output:
+  file_path: /src/fastlane/fluidattacks/results.csv
+  format: CSV
+
+# The working directory should resolve to the root of the repository.
+# This should stay "/src" because the tool doesn't seem to handle anything but the default too well.
+working_dir: /src
+language: EN
+file_size_limit: false
+
+# The "/src/apk_files" folder is deleted once the tool is done.
+# The folders named after the apks (e.g. "presentation-playstore-debug" for
+# "presentation-playstore-debug.apk") in "/src" seem to always stay empty.
+# If this behavior changes, it might be necessary to exclude those from "sast" to keep iterative scans possible.
+apk:
+  include:
+    - glob(/src/fastlane/fluidattacks/apks/**/*.apk)
+sast: # Used to be "path" (e.g. in the docs of the ADA)
+  include:
+    - .
+checks:
+  - F001
+  - F004
+  - F008
+  - F009
+  - F010
+  - F011
+  - F012
+  - F015
+  - F016
+  - F017
+  - F020
+  - F021
+  - F022
+  - F023
+  - F031
+  - F034
+  - F035
+  - F037
+  - F042
+  - F043
+  - F052
+  - F055
+  - F056
+  - F058
+  - F073
+  - F075
+  - F079
+  - F080
+  - F082
+  - F085
+  - F086
+  - F089
+  - F091
+  - F092
+  - F094
+  - F096
+  - F098
+  - F099
+  - F100
+  - F103
+  - F107
+  - F112
+  - F120
+  - F127
+  - F128
+  - F129
+  - F130
+  - F131
+  - F132
+  - F133
+  - F134
+  - F143
+  - F160
+  - F176
+  - F177
+  - F182
+  - F200
+  - F203
+  - F206
+  - F207
+  - F211
+  - F234
+  - F239
+  - F246
+  - F247
+  - F250
+  - F252
+  - F256
+  - F257
+  - F258
+  - F259
+  - F266
+  - F267
+  - F268
+  - F277
+  - F281
+  - F300
+  - F313
+  - F320
+  - F325
+  - F333
+  - F335
+  - F338
+  - F346
+  - F363
+  - F372
+  - F380
+  - F381
+  - F393
+  - F394
+  - F396
+  - F398
+  - F400
+  - F401
+  - F402
+  - F406
+  - F407
+  - F408
+  - F409
+  - F411
+  - F412
+  - F413
+  - F414
+  - F416
+  - F418


### PR DESCRIPTION
This PR sets up the [Fluid Attacks CLI tool](https://docs.fluidattacks.com/tech/scanner/standalone/cli/) to prepare for the CASA tier 2 audit.

- [X] Add tool to project.
- [x] Add fastlane lane.

Also see: https://github.com/cryptomator/ios/pull/340

