### PR TITLE
Update FAQ link at CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 - Ensure you're running the latest version of Cryptomator.
 - Ensure the bug is related to the Android version of Cryptomator. Bugs concerning the Cryptomator desktop application and iOS app can be reported on the [Cryptomator issues list](https://github.com/cryptomator/cryptomator/issues) and [Cryptomator for iOS issues list](https://github.com/cryptomator/cryptomator-ios/issues) respectively.
-- Ensure the bug was not [already reported](https://github.com/cryptomator/android/issues). You can also check out our [FAQ](https://community.cryptomator.org/c/faq).
+- Ensure the bug was not [already reported](https://github.com/cryptomator/android/issues). You can also check out our [FAQ](https://community.cryptomator.org/c/kb/faq).
 - If you're unable to find an open issue addressing the problem, [submit a new one](https://github.com/cryptomator/android/issues/new).
 
 ## Code of Conduct


### PR DESCRIPTION
Update FAQ link at CONTRIBUTING.md. Currently, it displays "Oops! That page doesn’t exist or is private."