### PR TITLE
Fix: ensure OneDrive config directory exists before writing file

### DIFF
--- a/presentation/prebuild.gradle
+++ b/presentation/prebuild.gradle
@@ -26,6 +26,7 @@ task generateAppConfigurationFile() {
 	}"""
 
 	def config_file = new File('presentation/src/main/res/raw/auth_config_onedrive.json')
+	config_file.parentFile.mkdirs()
 	config_file.write(JsonOutput.prettyPrint(JsonOutput.toJson(jsonSlurper.parseText(jsonString))))
 }
 


### PR DESCRIPTION
This adds `config_file.parentFile.mkdirs()` in `presentation/prebuild.gradle` to prevent build failures in clean environments (like Termux, CI containers) whenever `presentation/src/main/res/raw/` doesn't exist yet.

This change is platform-safe and has no effect when the directory already exists.